### PR TITLE
Update lineage_tissot.mk

### DIFF
--- a/lineage_tissot.mk
+++ b/lineage_tissot.mk
@@ -26,7 +26,7 @@ TARGET_VENDOR := Xiaomi
 PRODUCT_GMS_CLIENTID_BASE := android-xiaomi
 
 PRODUCT_BUILD_PROP_OVERRIDES += \
-    PRIVATE_BUILD_DESC="tissot-user 8.0.0 OPR1.170623.026 8.1.10 release-keys"
+    PRIVATE_BUILD_DESC="tissot-user 9 PKQ1.180917.001 V10.0.24.0.PDHMIXM release-keys"
 
 # Set BUILD_FINGERPRINT variable to be picked up by both system and vendor build.prop
-BUILD_FINGERPRINT := "xiaomi/tissot/tissot_sprout:8.0.0/OPR1.170623.026/8.1.10:user/release-keys"
+BUILD_FINGERPRINT := "xiaomi/tissot/tissot_sprout:9/PKQ1.180917.001/V10.0.24.0.PDHMIXM:user/release-keys"


### PR DESCRIPTION
Fixes broken child account with familylink 


Familylink complains otherwise that system needs an upgrade and therefore no child account can be added. 

https://gitlab.com/LineageOS/issues/android/-/issues/5188